### PR TITLE
Fix bug : Rename class OnKeyDownHook

### DIFF
--- a/Runtime/Hooks/OnKeyDownHook.cs
+++ b/Runtime/Hooks/OnKeyDownHook.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace GameplayIngredients.Hooks
 {
-    public class OnKeyDownAction : HookBase
+    public class OnKeyDownHook : HookBase
     {
         public enum ActionType
         {


### PR DESCRIPTION
OnKeyDownHook wasn't usable in unity because the name was no longer matching the file name