### PR TITLE
Game View Link : Cinemachine Brain Preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Preferences for Advanced Hierarchy View
 * Added API to AdvancedHierarchyView to add other Icons from component types
 * Help Menu links (github, documentation, openUPM)
+* Added an option to change the Game View Link camera behavior to Cinemachine Brain preview.
 
 #### Changed
 

--- a/Editor/GameViewLink/LinkGameView.cs
+++ b/Editor/GameViewLink/LinkGameView.cs
@@ -2,12 +2,14 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEditor;
+using Cinemachine;
 
 namespace GameplayIngredients.Editor
 {
     public static class LinkGameView
     {
         static readonly string kPreferenceName = "GameplayIngredients.LinkGameView";
+        static readonly string kCinemachinePreferenceName = "GameplayIngredients.LinkGameViewCinemachine";
         static readonly string kLinkCameraName = "___LINK__SCENE__VIEW__CAMERA___";
 
         public static bool Active
@@ -36,7 +38,32 @@ namespace GameplayIngredients.Editor
             }
         }
 
+        public static bool CinemachineActive
+        {
+            get
+            {
+                // Get preference only when not playing
+                if (!Application.isPlaying)
+                    m_CinemachineActive = EditorPrefs.GetBool(kCinemachinePreferenceName, false);
+
+                return m_CinemachineActive;
+            }
+
+            set
+            {
+                // Update preference only when not playing
+                if (!Application.isPlaying)
+                    EditorPrefs.SetBool(kCinemachinePreferenceName, value);
+
+                UpdateCinemachinePreview(value);
+
+                m_CinemachineActive = value;
+            }
+        }
+
         static bool m_Active = false;
+        static bool m_CinemachineActive = false;
+
 
 
         public static SceneView LockedSceneView
@@ -99,7 +126,6 @@ namespace GameplayIngredients.Editor
         
         static GameObject s_GameObject;
 
-
         static void Update(SceneView sceneView)
         {
             // Check if camera Exists
@@ -132,7 +158,7 @@ namespace GameplayIngredients.Editor
                 }
             }
 
-            if (Active)
+            if (Active && !CinemachineActive)
             {
                 var sv = s_LockedSceneView == null ? SceneView.lastActiveSceneView : s_LockedSceneView;
                 var sceneCamera = sv.camera;
@@ -155,12 +181,12 @@ namespace GameplayIngredients.Editor
             }
         }
 
-        const string kDefaultPrefabName = "LinkGameViewCamera";
+        const string kDefaultLinkPrefabName = "LinkGameViewCamera";
 
         static GameObject CreateLinkedCamera()
         {
             // Try to find an Asset named as the default name
-            string[] assets = AssetDatabase.FindAssets(kDefaultPrefabName);
+            string[] assets = AssetDatabase.FindAssets(kDefaultLinkPrefabName);
             if(assets.Length > 0)
             {
                 string path = AssetDatabase.GUIDToAssetPath(assets[0]);
@@ -196,6 +222,21 @@ namespace GameplayIngredients.Editor
             camera.depth = int.MaxValue;
             go.SetActive(Active);
             return go;
+        }
+
+        static void UpdateCinemachinePreview(bool value)
+        {
+            if (s_GameObject == null)
+                return;
+
+            CinemachineBrain brain;
+
+            if (!s_GameObject.TryGetComponent<CinemachineBrain>(out brain))
+            {
+                brain = s_GameObject.AddComponent<CinemachineBrain>();
+            }
+
+            brain.enabled = value;
         }
 
     }

--- a/Editor/GameViewLink/LinkGameView.cs
+++ b/Editor/GameViewLink/LinkGameView.cs
@@ -97,6 +97,12 @@ namespace GameplayIngredients.Editor
                     Active = true;
                 else
                     Active = false;
+
+                if (CinemachineActive)
+                    CinemachineActive = true;
+                else
+                    CinemachineActive = false;
+
             }
             else // Cleanup before switching state
             {

--- a/Editor/GameplayIngredients-Editor.asmdef
+++ b/Editor/GameplayIngredients-Editor.asmdef
@@ -5,7 +5,8 @@
         "NaughtyAttributes>Editor",
         "GameplayIngredients",
         "Unity.ugui",
-        "Unity.Timeline"
+        "Unity.Timeline",
+        "Cinemachine"
     ],
     "includePlatforms": [
         "Editor"
@@ -16,5 +17,6 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": []
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Editor/SceneViewToolbar.cs
+++ b/Editor/SceneViewToolbar.cs
@@ -53,11 +53,19 @@ namespace GameplayIngredients.Editor
                         GUI.color = Color.green *2;
                     }
 
-                    isLinked = GUILayout.Toggle(isLinked, Contents.linkGameView, EditorStyles.toolbarButton, GUILayout.Width(64));
+                    isLinked = GUILayout.Toggle(isLinked, LinkGameView.CinemachineActive? Contents.linkGameViewCinemachine: Contents.linkGameView, EditorStyles.toolbarButton, GUILayout.Width(64));
 
                     if (GUI.changed)
                     {
-                        LinkGameView.Active = isLinked;
+                        if(Event.current.shift)
+                        {
+                            if (!LinkGameView.Active)
+                                LinkGameView.Active = true;
+
+                            LinkGameView.CinemachineActive = !LinkGameView.CinemachineActive;
+                        }
+                        else
+                            LinkGameView.Active = isLinked;
                     }
 
                     isLocked = GUILayout.Toggle(isLocked, Contents.lockLinkGameView, EditorStyles.toolbarButton);
@@ -104,12 +112,18 @@ namespace GameplayIngredients.Editor
             public static GUIContent playFromHere;
             public static GUIContent lockLinkGameView;
             public static GUIContent linkGameView;
+            public static GUIContent linkGameViewCinemachine;
 
             static Contents()
             {
                 lockLinkGameView = new GUIContent(EditorGUIUtility.IconContent("IN LockButton"));
                 linkGameView = new GUIContent(EditorGUIUtility.Load("Packages/net.peeweek.gameplay-ingredients/Icons/GUI/Camera16x16.png") as Texture);
                 linkGameView.text = " Game";
+
+                linkGameViewCinemachine = new GUIContent(EditorGUIUtility.Load("Packages/net.peeweek.gameplay-ingredients/Icons/GUI/Camera16x16.png") as Texture);
+                linkGameViewCinemachine.text = " Cine";
+
+
 
                 playFromHere = new GUIContent(EditorGUIUtility.IconContent("Animation.Play"));
                 playFromHere.text = "Here";

--- a/Editor/SceneViewToolbar.cs
+++ b/Editor/SceneViewToolbar.cs
@@ -50,7 +50,11 @@ namespace GameplayIngredients.Editor
 
                     if(isLinked && isLocked)
                     {
-                        GUI.color = Color.green *2;
+                        GUI.color = Styles.lockedLinkColor * 2;
+                    }
+                    else if (isLinked && LinkGameView.CinemachineActive)
+                    {
+                        GUI.color = Styles.cineColor * 2;
                     }
 
                     isLinked = GUILayout.Toggle(isLinked, LinkGameView.CinemachineActive? Contents.linkGameViewCinemachine: Contents.linkGameView, EditorStyles.toolbarButton, GUILayout.Width(64));
@@ -65,7 +69,10 @@ namespace GameplayIngredients.Editor
                             LinkGameView.CinemachineActive = !LinkGameView.CinemachineActive;
                         }
                         else
+                        {
                             LinkGameView.Active = isLinked;
+                            LinkGameView.CinemachineActive = false;
+                        }
                     }
 
                     isLocked = GUILayout.Toggle(isLocked, Contents.lockLinkGameView, EditorStyles.toolbarButton);
@@ -74,6 +81,7 @@ namespace GameplayIngredients.Editor
                     {
                         if (isLocked)
                         {
+                            LinkGameView.CinemachineActive = false;
                             LinkGameView.LockedSceneView = sceneView;
                         }
                         else
@@ -104,7 +112,36 @@ namespace GameplayIngredients.Editor
 
                 }
             }
+
+            if (LinkGameView.CinemachineActive)
+            {
+                DisplayText("CINEMACHINE PREVIEW", Styles.cineColor);
+            }
+            else if (LinkGameView.Active)
+            {
+                if (LinkGameView.LockedSceneView == sceneView)
+                {
+                    DisplayText("GAME VIEW LINKED (LOCKED)", Styles.lockedLinkColor);
+                }
+                else if(LinkGameView.LockedSceneView == null && SceneView.lastActiveSceneView == sceneView)
+                {
+                    DisplayText("GAME VIEW LINKED", Color.white);
+                }
+            }
+
             Handles.EndGUI();
+        }
+
+        static void DisplayText(string text, Color color)
+        {
+            Rect r = new Rect(16, 24, 512, 32);
+            GUI.color = Color.black;
+            GUI.Label(r, text);
+            r.x--;
+            r.y--;
+            GUI.color = color;
+            GUI.Label(r, text);
+            GUI.color = Color.white;
         }
 
         static class Contents
@@ -133,6 +170,8 @@ namespace GameplayIngredients.Editor
         static class Styles
         {
             public static GUIStyle toolbar;
+            public static Color lockedLinkColor = new Color(0.5f, 1.0f, 0.1f, 1.0f);
+            public static Color cineColor = new Color(1.0f, 0.5f, 0.1f, 1.0f);
 
             static Styles()
             {


### PR DESCRIPTION
Adds an option to set an alternate Game View Link mode : Cine Mode.
Cine mode disables automatic following of the scene view, but instead uses a Cinemachine Brain component to preview any cinemachine animation (eg: VCams animated using timeline)