### PR TITLE
Fixed Welcome screen from showing up on domain reload.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Fixed
 
 * Fixed Take Screenshot Action : bad filename + tooltips
+* Fixed Welcome screen from showing up on domain reload.
 
 ## 2019.3.6
 

--- a/Editor/WelcomeScreen/WelcomeScreen.cs
+++ b/Editor/WelcomeScreen/WelcomeScreen.cs
@@ -41,13 +41,23 @@ namespace GameplayIngredients.Editor
         {
             if (showOnStartup && !GameplayIngredientsSettings.currentSettings.disableWelcomeScreenAutoStart)
                 EditorApplication.update += ShowAtStartup;
+
+            EditorApplication.quitting += EditorApplication_quitting;
+        }
+
+        const string kShowNextPreference = "GameplayIngredients.WelcomeScreen.ShowNextTime";
+
+        private static void EditorApplication_quitting()
+        {
+            EditorPrefs.SetBool(kShowNextPreference, true);
         }
 
         static void ShowAtStartup()
         {
-            if (!Application.isPlaying)
+            if (!Application.isPlaying && EditorPrefs.GetBool(kShowNextPreference, true))
             {
                 ShowFromMenu();
+                EditorPrefs.SetBool(kShowNextPreference, false);
             }
             EditorApplication.update -= ShowAtStartup;
         }


### PR DESCRIPTION
This fixes a domain reload issue where welcome screen was showing up if needing to be visible at startup.

As there's no "Once per session" callback, the behavior now relies on EditorPref that will set to false once startup has shown it once, then will set it to true upon editor closing so it's visible next startup.