### PR TITLE
Scene View Toolbar Preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Added abstract `PingableEditor` class for MonoBehaviours that can be Pinged to stand out in the inspector.
 * Added Help items in Menu, Added HelpURL class attributes
 * Feature: Scene Comments
+* Added preferences to control visibility of buttons in Additional Scene View Toolbar
 
 ## 2020.2.2
 

--- a/Editor/SceneViewToolbar.cs
+++ b/Editor/SceneViewToolbar.cs
@@ -232,13 +232,25 @@ namespace GameplayIngredients.Editor
             [SettingsProvider]
             public static SettingsProvider GetPreferences()
             {
-                static void PreferenceItem(string label, string name)
+                static void OnToggleAll(bool toggle)
+                {
+                    OnToggleLinkGameView(toggle);
+                }
+
+                static void OnToggleLinkGameView(bool toggle)
+                {
+                    if (!toggle)
+                        LinkGameView.Active = false;
+                }
+
+                static void PreferenceItem(string label, string name, Action<bool> onToggle = null)
                 {
                     EditorGUI.BeginChangeCheck();
                     bool val = EditorGUILayout.Toggle(label, Get(name));
                     if (EditorGUI.EndChangeCheck())
                     {
                         Set(name, val);
+                        onToggle?.Invoke(val);
                         SceneView.RepaintAll();
                     }
                 };
@@ -248,11 +260,11 @@ namespace GameplayIngredients.Editor
                     label = "Scene View",
                     guiHandler = (searchContext) =>
                     {
-                        PreferenceItem("Show Toolbar", "showToolbar");
+                        PreferenceItem("Show Toolbar", "showToolbar", OnToggleAll);
                         using (new EditorGUI.IndentLevelScope(1))
                         {
                             PreferenceItem("Play From Here", kShowPlayFromHere);
-                            PreferenceItem("Link Game View", kShowLinkGameView);
+                            PreferenceItem("Link Game View", kShowLinkGameView, OnToggleLinkGameView);
                             PreferenceItem("Point of View", kShowPOV);
                             PreferenceItem("Check Window", kShowCheck);
                             PreferenceItem("Comments Window", kShowComments);
@@ -261,6 +273,8 @@ namespace GameplayIngredients.Editor
                     }
                 };
             }
+
+
         }
 
         static class Contents


### PR DESCRIPTION
Adds preferences in order to customize the visibility of the additional Scene View Toolbar
* Entire Visibility
* Individual Items
* Play from Here now becomes disabled instead of invisible if not set-up
* Items are located in preferences

TODO:
* Check for disabling a feature upon toggle of visibility