### PR TITLE
Handle drop in Callable Reorderable Lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 #### Added
 
-* Handle Drop in Callable Reorderable Lists
+* Handle Drop in Callable Reorderable Lists : Dropped Callables components are added to the list. Dropped Game Objects will prompt a menu to select which callable to add.
+
+#### Fixed
+
+* Fixed Callable Reorderable List Undo.
 
 ## 2020.2.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2020.2.6
 
+#### Added
+
+* Handle Drop in Callable Reorderable Lists
+
 ## 2020.2.5
 
 #### Added

--- a/Editor/BrowsePopup/CallableProvider.cs
+++ b/Editor/BrowsePopup/CallableProvider.cs
@@ -105,6 +105,7 @@ namespace GameplayIngredients.Editor
 
         static void AddCallable()
         {
+            Undo.RecordObject(addNextComponentInfo.gameObject, "Add Callable");
             addNextComponentInfo.gameObject.AddCallable(
                addNextComponentInfo.component,
                addNextComponentInfo.propertyName,

--- a/Editor/PropertyDrawers/CallableReorderableList.cs
+++ b/Editor/PropertyDrawers/CallableReorderableList.cs
@@ -41,7 +41,28 @@ namespace GameplayIngredients.Editor
                         Object[] droppedObjects = DragAndDrop.objectReferences;
                         foreach (Object obj in droppedObjects)
                         {
-                            if (obj != null && obj is Callable)
+                            if(obj != null && obj is GameObject)
+                            {
+                                DragAndDrop.visualMode = DragAndDropVisualMode.Copy;
+                                if (currentEvent.type == EventType.DragPerform)
+                                {
+                                    GenericMenu m = new GenericMenu();
+                                    var callables = (obj as GameObject).GetComponents<Callable>();
+                                    foreach(var c in callables)
+                                    {
+                                        m.AddItem(new GUIContent($"{c.Name} ({c.GetType().Name})"), false, () => {
+                                            list.serializedProperty.serializedObject.Update();
+                                            list.serializedProperty.arraySize++;
+                                            int arrayEnd = list.serializedProperty.arraySize - 1;
+                                            list.serializedProperty.GetArrayElementAtIndex(arrayEnd).objectReferenceValue = c;
+                                            list.serializedProperty.serializedObject.ApplyModifiedProperties();
+                                        });
+                                    }
+                                    m.ShowAsContext();
+                                    acceptAtLeastOne = true;
+                                }
+                            }
+                            else if (obj != null && obj is Callable)
                             {
                                 DragAndDrop.visualMode = DragAndDropVisualMode.Copy;
                                 if (currentEvent.type == EventType.DragPerform)
@@ -108,7 +129,7 @@ namespace GameplayIngredients.Editor
 
             if (t != null && typeof(Callable).IsAssignableFrom(t))
             {
-                var newCmp = gameObject.AddComponent(t);
+                var newCmp = Undo.AddComponent(gameObject, t);
                 field.SetValue(component, val.Append(newCmp as Callable));
             }
             else

--- a/Editor/PropertyDrawers/CallableReorderableList.cs
+++ b/Editor/PropertyDrawers/CallableReorderableList.cs
@@ -2,7 +2,6 @@ using UnityEngine;
 using UnityEditor;
 using UnityEditorInternal;
 using System.Linq;
-using System;
 
 namespace GameplayIngredients.Editor
 {
@@ -19,6 +18,55 @@ namespace GameplayIngredients.Editor
         void DrawHeader(Rect r)
         {
             GUI.Label(r, new GUIContent($"  {serializedProperty.displayName}", Styles.callableIcon), EditorStyles.boldLabel);
+            HandleDrop(r, this);
+        }
+
+        void HandleDrop(Rect rect, CallableReorderableList list)
+        {
+            var currentEvent = Event.current;
+            var usedEvent = false;
+
+            switch (currentEvent.type)
+            {
+                case EventType.DragExited:
+                    if (GUI.enabled)
+                        HandleUtility.Repaint();
+                    break;
+
+                case EventType.DragUpdated:
+                case EventType.DragPerform:
+                    if (rect.Contains(currentEvent.mousePosition) && GUI.enabled)
+                    {
+                        bool acceptAtLeastOne = false;
+                        Object[] droppedObjects = DragAndDrop.objectReferences;
+                        foreach (Object obj in droppedObjects)
+                        {
+                            if (obj != null && obj is Callable)
+                            {
+                                DragAndDrop.visualMode = DragAndDropVisualMode.Copy;
+                                if (currentEvent.type == EventType.DragPerform)
+                                {
+                                    list.serializedProperty.arraySize++;
+                                    int arrayEnd = list.serializedProperty.arraySize - 1;
+                                    list.serializedProperty.GetArrayElementAtIndex(arrayEnd).objectReferenceValue = obj as Callable;
+                                    acceptAtLeastOne = true;
+                                }
+                            }
+                        }
+
+                        if (acceptAtLeastOne)
+                        {
+                            GUI.changed = true;
+                            DragAndDrop.AcceptDrag();
+                            usedEvent = true;
+                        }
+                    }
+                    break;
+            }
+
+            if (usedEvent)
+                currentEvent.Use();
+
         }
 
         void DrawElement(Rect r, int index, bool isActive, bool isFocused)
@@ -53,7 +101,7 @@ namespace GameplayIngredients.Editor
 
     public static class CallableExtensions
     {
-        public static void AddCallable(this GameObject gameObject, Component component, string propertyName, Type t)
+        public static void AddCallable(this GameObject gameObject, Component component, string propertyName, System.Type t)
         {
             var field = component.GetType().GetFields().Where(f => f.Name == propertyName).FirstOrDefault();
             var val = field.GetValue(component) as Callable[];


### PR DESCRIPTION
New UX:
- [x] Dropping Callable Components on header will add them to the list
- [x] Dropping Game Objects on header will search for any callable on the game objects, and show a menu to add them.
- [x] Fix undo in Callable Reorderable List

