### PR TITLE
Handle Presence of Modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Fixed Callable Reorderable List Undo
 * Fixed Out of sync Ingredients explorer Window : now Syncs upon Selection Change.
+* Handle Presence of Optional Modules
 
 ## 2020.2.5
 

--- a/Runtime/Attributes/CallableAttribute.cs
+++ b/Runtime/Attributes/CallableAttribute.cs
@@ -1,13 +1,18 @@
 using System;
 
-[AttributeUsage(AttributeTargets.Class)]
-public class CallableAttribute : Attribute 
+namespace GameplayIngredients
 {
-    public string category;
-    public string iconPath;
-    public CallableAttribute(string category = "", string iconName = "")
+    [AttributeUsage(AttributeTargets.Class)]
+    public class CallableAttribute : Attribute
     {
-        this.category = category;
-        this.iconPath = iconName;
+        public string category;
+        public string iconPath;
+        public CallableAttribute(string category = "", string iconName = "")
+        {
+            this.category = category;
+            this.iconPath = iconName;
+        }
     }
 }
+
+

--- a/Runtime/Attributes/WarnDisabledModuleAttribute.cs
+++ b/Runtime/Attributes/WarnDisabledModuleAttribute.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace GameplayIngredients
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public class WarnDisabledModuleAttribute : Attribute
+    {
+        public string module;
+
+        public WarnDisabledModuleAttribute(string module)
+        {
+            this.module = module;
+        }
+    }
+}
+
+

--- a/Runtime/Attributes/WarnDisabledModuleAttribute.cs.meta
+++ b/Runtime/Attributes/WarnDisabledModuleAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 74b211a1354ee114ea4d2f79cbe73a69
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/GameplayIngredients.asmdef
+++ b/Runtime/GameplayIngredients.asmdef
@@ -1,5 +1,6 @@
 {
     "name": "GameplayIngredients",
+    "rootNamespace": "",
     "references": [
         "NaughtyAttributes.Core",
         "Cinemachine",
@@ -13,6 +14,12 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.modules.physics2d",
+            "expression": "1.0.0",
+            "define": "MODULE_PHYSICS2D"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/Runtime/GameplayIngredients.asmdef
+++ b/Runtime/GameplayIngredients.asmdef
@@ -19,6 +19,11 @@
             "name": "com.unity.modules.physics2d",
             "expression": "1.0.0",
             "define": "MODULE_PHYSICS2D"
+        },
+        {
+            "name": "com.unity.modules.screencapture",
+            "expression": "1.0.0",
+            "define": "MODULE_SCREENCAPTURE"
         }
     ],
     "noEngineReferences": false

--- a/Runtime/LevelScripting/Actions/TakeScreenshotAction.cs
+++ b/Runtime/LevelScripting/Actions/TakeScreenshotAction.cs
@@ -2,6 +2,9 @@ using UnityEngine;
 
 namespace GameplayIngredients.Actions
 {
+#if !MODULE_SCREENCAPTURE
+    [WarnDisabledModule("Screen Capture")]
+#endif
     [AddComponentMenu(ComponentMenu.actionsPath + "Take Screenshot Action")]
     [Callable("Screen", "Actions/ic-action-screen.png")]
     public class TakeScreenshotAction : ActionBase
@@ -16,8 +19,12 @@ namespace GameplayIngredients.Actions
 
         public override void Execute(GameObject instigator = null)
         {
+#if MODULE_SCREENCAPTURE
             ScreenCapture.CaptureScreenshot(fileName + screenshotNumber.ToString().PadLeft(figureCount, '0') + ".png", supersampleRate);
             screenshotNumber += 1;
+#else
+            Debug.Log("TakeScreenshotAction Cannot Take Screenshot : Unity Module Screen Capture is Disabled.");
+#endif
         }
 
         public override string GetDefaultName()

--- a/Runtime/LevelScripting/Events/OnCollider2DEvent.cs
+++ b/Runtime/LevelScripting/Events/OnCollider2DEvent.cs
@@ -1,4 +1,5 @@
-﻿using NaughtyAttributes;
+﻿#if MODULE_PHYSICS2D
+using NaughtyAttributes;
 using UnityEngine;
 
 namespace GameplayIngredients.Events
@@ -39,3 +40,4 @@ namespace GameplayIngredients.Events
         }
     }
 }
+#endif

--- a/Runtime/LevelScripting/Events/OnCollider2DEvent.cs
+++ b/Runtime/LevelScripting/Events/OnCollider2DEvent.cs
@@ -1,11 +1,15 @@
-﻿#if MODULE_PHYSICS2D
-using NaughtyAttributes;
+﻿using NaughtyAttributes;
 using UnityEngine;
 
 namespace GameplayIngredients.Events
 {
+#if !MODULE_PHYSICS2D
+    [WarnDisabledModule("Physics 2D")]
+#endif
     [AddComponentMenu(ComponentMenu.eventsPath + "On Collider 2D Event")]
+#if MODULE_PHYSICS2D
     [RequireComponent(typeof(Collider2D))]
+#endif
     public class OnCollider2DEvent : EventBase
     {
         public Callable[] onCollisionEnter;
@@ -15,6 +19,7 @@ namespace GameplayIngredients.Events
         [EnableIf("OnlyInteractWithTag")]
         public string Tag = "Player";
 
+#if MODULE_PHYSICS2D
         private void OnCollisionEnter2D(Collision2D other)
         {
             if (OnlyInteractWithTag && other.collider.tag == Tag)
@@ -38,6 +43,6 @@ namespace GameplayIngredients.Events
                 Callable.Call(onCollisionExit, other.collider.gameObject);
             }
         }
+#endif
     }
 }
-#endif

--- a/Runtime/LevelScripting/Events/OnTrigger2DEvent.cs
+++ b/Runtime/LevelScripting/Events/OnTrigger2DEvent.cs
@@ -1,3 +1,4 @@
+#if MODULE_PHYSICS2D
 using NaughtyAttributes;
 using UnityEngine;
 
@@ -39,3 +40,4 @@ namespace GameplayIngredients.Events
         }
     }
 }
+#endif

--- a/Runtime/LevelScripting/Events/OnTrigger2DEvent.cs
+++ b/Runtime/LevelScripting/Events/OnTrigger2DEvent.cs
@@ -1,11 +1,16 @@
-#if MODULE_PHYSICS2D
 using NaughtyAttributes;
 using UnityEngine;
 
 namespace GameplayIngredients.Events
 {
+#if !MODULE_PHYSICS2D
+    [WarnDisabledModule("Physics 2D")]
+#endif
     [AddComponentMenu(ComponentMenu.eventsPath + "On Trigger 2D Event")]
     [AdvancedHierarchyIcon("Packages/net.peeweek.gameplay-ingredients/Icons/Events/ic-event-trigger.png")]
+#if MODULE_PHYSICS2D
+    [RequireComponent(typeof(Collider2D))]
+#endif
     public class OnTrigger2DEvent : EventBase
     {
         public Callable[] onTriggerEnter;
@@ -15,6 +20,7 @@ namespace GameplayIngredients.Events
         [EnableIf("OnlyInteractWithTag")]
         public string Tag = "Player";
 
+#if MODULE_PHYSICS2D
         private void OnTriggerEnter2D(Collider2D other)
         {
             if (OnlyInteractWithTag && other.tag == Tag )
@@ -38,6 +44,7 @@ namespace GameplayIngredients.Events
                 Callable.Call(onTriggerExit, other.gameObject);
             }
         }
+#endif
     }
 }
-#endif
+

--- a/Runtime/LevelScripting/Events/OnTriggerEvent.cs
+++ b/Runtime/LevelScripting/Events/OnTriggerEvent.cs
@@ -5,6 +5,7 @@ namespace GameplayIngredients.Events
 {
     [AddComponentMenu(ComponentMenu.eventsPath + "On Trigger Event")]
     [AdvancedHierarchyIcon("Packages/net.peeweek.gameplay-ingredients/Icons/Events/ic-event-trigger.png")]
+    [RequireComponent(typeof(Collider))]
     public class OnTriggerEvent : EventBase
     {
         public Callable[] onTriggerEnter;

--- a/Runtime/Managers/Implementations/ScreenshotManager.cs
+++ b/Runtime/Managers/Implementations/ScreenshotManager.cs
@@ -2,6 +2,9 @@ using UnityEngine;
 
 namespace GameplayIngredients
 {
+#if !MODULE_SCREENCAPTURE
+    [WarnDisabledModule("Screen Capture")]
+#endif
     [AddComponentMenu(ComponentMenu.managersPath + "Screenshot Manager")]
     [ManagerDefaultPrefab("ScreenshotManager")]
     public class ScreenshotManager : Manager
@@ -22,12 +25,16 @@ namespace GameplayIngredients
         {
             if (Input.GetKeyDown(ScreenshotKeyCode))
             {
+#if MODULE_SCREENCAPTURE
                 var now = System.DateTime.Now;
                 Callable.Call(OnBeforeScreenshot);
                 string path = $"{Application.dataPath}/../{Prefix}-{now.Year}{now.Month}{now.Day}-{now.Hour}{now.Minute}{now.Second}{now.Millisecond}.png";
                 Debug.Log($"Capturing Screenshot (Supersampled to {SuperSize}x) to the file : {path}");
                 ScreenCapture.CaptureScreenshot(path, SuperSize);
                 Callable.Call(OnAfterScreenshot);
+#else
+                Debug.Log("Screenshot Manager Cannot Take Screenshot : Unity Module Screen Capture is Disabled.");
+#endif
             }
         }
     }


### PR DESCRIPTION
This PR adds assembly definition defines in order to handle correctly the presence/absence of the following modules. Scripts that are using these modules will be enabled in the Asmdef depending on the presence of the module.

- [x] 2D Physics
- [x] Screen Capture