### PR TITLE
Improved Selection History

### DIFF
--- a/Editor/SelectionHistory/SelectionHistoryWindow.cs
+++ b/Editor/SelectionHistory/SelectionHistoryWindow.cs
@@ -35,10 +35,6 @@ namespace GameplayIngredients.Editor
             EditorGUILayout.EndScrollView();
         }
 
-        public bool ignoreNextSelection = false;
-
-
-
         public bool CompareArray(Object[] a, Object[] b)
         {
             return a.SequenceEqual(b);
@@ -98,7 +94,6 @@ namespace GameplayIngredients.Editor
                             GUILayout.Label(label, Styles.icon);
                             if (GUILayout.Button($"{name} ({obj.GetType().Name})", Styles.historyItem))
                             {
-                                ignoreNextSelection = true;
                                 Selection.activeObject = obj;
                             }
 
@@ -106,7 +101,6 @@ namespace GameplayIngredients.Editor
                             {
                                 if (GUILayout.Button("Focus", Styles.historyButton, GUILayout.Width(48)))
                                 {
-                                    ignoreNextSelection = true;
                                     Selection.activeObject = obj;
                                     SceneView.lastActiveSceneView.FrameSelected();
                                 }
@@ -169,7 +163,7 @@ namespace GameplayIngredients.Editor
                         GUILayout.Label(label, Styles.icon);
                         if (GUILayout.Button($"{name} ({obj.GetType().Name})", Styles.historyItem))
                         {
-                            ignoreNextSelection = true;
+
                             Selection.activeObject = obj;
                         }
 
@@ -177,7 +171,6 @@ namespace GameplayIngredients.Editor
                         {
                             if (GUILayout.Button("Focus", Styles.historyButton, GUILayout.Width(48)))
                             {
-                                ignoreNextSelection = true;
                                 Selection.activeObject = obj;
                                 SceneView.lastActiveSceneView.FrameSelected();
                             }
@@ -222,12 +215,6 @@ namespace GameplayIngredients.Editor
 
             static void OnSelectionChange()
             {
-                if (SelectionHistoryWindow.instance != null && SelectionHistoryWindow.instance.ignoreNextSelection)
-                {
-                    SelectionHistoryWindow.instance.ignoreNextSelection = false;
-                    return;
-                }
-
                 if (selectionHistory == null) selectionHistory = new List<Object>();
                 if (lockedObjects == null) lockedObjects = new List<Object>();
 

--- a/Editor/SelectionHistory/SelectionHistoryWindow.cs
+++ b/Editor/SelectionHistory/SelectionHistoryWindow.cs
@@ -1,7 +1,5 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using UnityEngine;
 using UnityEditor;
 
@@ -40,8 +38,10 @@ namespace GameplayIngredients.Editor
             selectionHistory = null;
         }
 
-        List<UnityEngine.Object> selectionHistory;
-        List<UnityEngine.Object> lockedObjects;
+        [SerializeField]
+        List<Object> selectionHistory;
+        [SerializeField]
+        List<Object> lockedObjects;
 
         int maxHistoryCount = 32;
         bool ignoreNextSelection = false;
@@ -54,8 +54,8 @@ namespace GameplayIngredients.Editor
                 return;
             }
 
-            if (selectionHistory == null) selectionHistory = new List<UnityEngine.Object>();
-            if (lockedObjects == null) lockedObjects = new List<UnityEngine.Object>();
+            if (selectionHistory == null) selectionHistory = new List<Object>();
+            if (lockedObjects == null) lockedObjects = new List<Object>();
 
             if (Selection.activeObject != null || Selection.objects.Length > 0)
             {
@@ -68,21 +68,20 @@ namespace GameplayIngredients.Editor
 
                 if (selectionHistory.Count > maxHistoryCount)
                     selectionHistory.Take(maxHistoryCount);
-
-                Repaint();
             }
 
+            Repaint();
         }
 
-        public bool CompareArray(UnityEngine.Object[] a, UnityEngine.Object[] b)
+        public bool CompareArray(Object[] a, Object[] b)
         {
             return a.SequenceEqual(b);
         }
 
         void Selection_OnGUI()
         {
-            if (selectionHistory == null) selectionHistory = new List<UnityEngine.Object>();
-            if (lockedObjects == null) lockedObjects = new List<UnityEngine.Object>();
+            if (selectionHistory == null) selectionHistory = new List<Object>();
+            if (lockedObjects == null) lockedObjects = new List<Object>();
             int i = 0;
             int toRemove = -1;
 
@@ -113,6 +112,9 @@ namespace GameplayIngredients.Editor
                     }
                     else
                     {
+                        bool highlight = Selection.objects.Contains(obj);
+                        GUI.backgroundColor = highlight ? Styles.highlightColor : Color.white;
+
                         using (new EditorGUILayout.HorizontalScope(Styles.historyLine))
                         {
                             var b = GUI.color;
@@ -168,12 +170,13 @@ namespace GameplayIngredients.Editor
 
 
             GUI.backgroundColor = Color.white;
-            var reversedHistory = selectionHistory.Reverse<UnityEngine.Object>().ToArray();
+            var reversedHistory = selectionHistory.Reverse<Object>().ToArray();
             foreach (var obj in reversedHistory)
             {
                 if (obj != null)
                 {
-                    bool highlight = Selection.gameObjects.Contains(obj);
+                    bool highlight = Selection.objects.Contains(obj);
+                    GUI.backgroundColor = highlight ? Styles.highlightColor : Color.white;      
 
                     using (new EditorGUILayout.HorizontalScope(Styles.historyLine))
                     {
@@ -196,7 +199,6 @@ namespace GameplayIngredients.Editor
                             ignoreNextSelection = true;
                             Selection.activeObject = obj;
                         }
-
 
                         if (obj is GameObject && GUILayout.Button("Focus", Styles.historyButton, GUILayout.Width(48)))
                         {
@@ -229,7 +231,7 @@ namespace GameplayIngredients.Editor
             public static GUIStyle historyItem;
             public static GUIStyle historyButton;
             public static GUIStyle highlight;
-            public static Color highlightColor = new Color(2.0f, 2.0f, 2.0f);
+            public static Color highlightColor = new Color(1.0f, 1.5f, 2.0f);
 
             public static GUIStyle icon;
 

--- a/Editor/SelectionHistory/SelectionHistoryWindow.cs
+++ b/Editor/SelectionHistory/SelectionHistoryWindow.cs
@@ -136,11 +136,18 @@ namespace GameplayIngredients.Editor
                                 Selection.activeObject = obj;
                             }
 
-                            if (obj is GameObject && GUILayout.Button("Focus", Styles.historyButton, GUILayout.Width(48)))
+                            if (obj is GameObject && !PrefabUtility.IsPartOfPrefabAsset(obj))
                             {
-                                ignoreNextSelection = true;
-                                Selection.activeObject = obj;
-                                SceneView.lastActiveSceneView.FrameSelected();
+                                if (GUILayout.Button("Focus", Styles.historyButton, GUILayout.Width(48)))
+                                {
+                                    ignoreNextSelection = true;
+                                    Selection.activeObject = obj;
+                                    SceneView.lastActiveSceneView.FrameSelected();
+                                }
+                            }
+                            else if (GUILayout.Button("Open", Styles.historyButton, GUILayout.Width(48)))
+                            {
+                                AssetDatabase.OpenAsset(obj);
                             }
                         }
                     }
@@ -200,11 +207,18 @@ namespace GameplayIngredients.Editor
                             Selection.activeObject = obj;
                         }
 
-                        if (obj is GameObject && GUILayout.Button("Focus", Styles.historyButton, GUILayout.Width(48)))
+                        if (obj is GameObject && !PrefabUtility.IsPartOfPrefabAsset(obj))  
                         {
-                            ignoreNextSelection = true;
-                            Selection.activeObject = obj;
-                            SceneView.lastActiveSceneView.FrameSelected();
+                            if (GUILayout.Button("Focus", Styles.historyButton, GUILayout.Width(48)))
+                            {
+                                ignoreNextSelection = true;
+                                Selection.activeObject = obj;
+                                SceneView.lastActiveSceneView.FrameSelected();
+                            }
+                        }
+                        else if (GUILayout.Button("Open", Styles.historyButton, GUILayout.Width(48)))
+                        {
+                            AssetDatabase.OpenAsset(obj);
                         }
                     }
 

--- a/Editor/SelectionHistory/SelectionHistoryWindow.cs
+++ b/Editor/SelectionHistory/SelectionHistoryWindow.cs
@@ -96,7 +96,7 @@ namespace GameplayIngredients.Editor
                             string name = label.text;
                             label.text = string.Empty;
                             GUILayout.Label(label, Styles.icon);
-                            if (GUILayout.Button(name, Styles.historyItem))
+                            if (GUILayout.Button($"{name} ({obj.GetType().Name})", Styles.historyItem))
                             {
                                 ignoreNextSelection = true;
                                 Selection.activeObject = obj;
@@ -167,7 +167,7 @@ namespace GameplayIngredients.Editor
                         string name = label.text;
                         label.text = string.Empty;
                         GUILayout.Label(label, Styles.icon);
-                        if (GUILayout.Button(name, Styles.historyItem))
+                        if (GUILayout.Button($"{name} ({obj.GetType().Name})", Styles.historyItem))
                         {
                             ignoreNextSelection = true;
                             Selection.activeObject = obj;


### PR DESCRIPTION
The PR adds the following changes to the Selection History Window:

- Support for UnityEngine.Object (instead of just Game Objects)
- History is tracked even if window is closed
- No more history limit
- Display of Object Icon and Type next to label
- Better handling of favorites (displayed in both history + favorites)
- UI Improvements
- Opens the Window with Alt+H

![image](https://user-images.githubusercontent.com/4037271/152669279-42822330-1ce8-46d0-b8c6-8142ca09e59c.png)
